### PR TITLE
Add pdf endpoint

### DIFF
--- a/lib/myob/api/models/base.rb
+++ b/lib/myob/api/models/base.rb
@@ -59,6 +59,13 @@ module Myob
           @client.connection.delete(self.url(object), :headers => @client.headers)
         end
 
+        def pdf(id)
+          object = { 'UID' => id }
+          url = self.url(object, format: "pdf")
+          response = @client.connection.get(url, headers: @client.headers)
+          response.body
+        end
+
         def url(object = nil, params = nil)
           url = if self.model_route == ''
             API_URL


### PR DESCRIPTION
Adds an endpoint to fetch invoice PDFs. Accessible through `client.{model_name}.pdf`